### PR TITLE
Update SDK and support Android 12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "taco.scoop"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 31
         versionName "2.3.1"
 

--- a/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
+++ b/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
@@ -71,7 +71,7 @@ public class CrashReceiver extends BroadcastReceiver {
             TaskStackBuilder stackBuilder = TaskStackBuilder.create(context)
                     .addParentStack(DetailActivity.class)
                     .addNextIntent(clickIntent);
-            PendingIntent clickPendingIntent = stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent clickPendingIntent = stackBuilder.getPendingIntent(0, Utils.getPendingIntentFlags());
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context, "crashes")
                     .setSmallIcon(R.drawable.ic_bug_report)
@@ -105,7 +105,7 @@ public class CrashReceiver extends BroadcastReceiver {
                         .putExtra("pkg", packageName)
                         .setAction(Intents.INTENT_ACTION_COPY);
                 PendingIntent copyPendingIntent = PendingIntent.getBroadcast(context,
-                        notificationId, copyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        notificationId, copyIntent, Utils.getPendingIntentFlags());
                 builder.addAction(new NotificationCompat.Action(R.drawable.ic_content_copy,
                         context.getString(R.string.action_copy_short), copyPendingIntent));
 
@@ -114,7 +114,7 @@ public class CrashReceiver extends BroadcastReceiver {
                         .putExtra("pkg", packageName)
                         .setAction(Intents.INTENT_ACTION_SHARE);
                 PendingIntent sharePendingIntent = PendingIntent.getBroadcast(context,
-                        notificationId, shareIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        notificationId, shareIntent, Utils.getPendingIntentFlags());
                 builder.addAction(new NotificationCompat.Action(R.drawable.ic_share,
                         context.getString(R.string.action_share), sharePendingIntent));
             }

--- a/app/src/main/java/taco/scoop/core/service/indicator/IndicatorService.kt
+++ b/app/src/main/java/taco/scoop/core/service/indicator/IndicatorService.kt
@@ -3,11 +3,13 @@ package taco.scoop.core.service.indicator
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import taco.scoop.R
 import taco.scoop.core.receiver.StopReceiver
+import taco.scoop.util.pendingIntentFlags
 
 open class IndicatorService : Service() {
 
@@ -24,7 +26,7 @@ open class IndicatorService : Service() {
             this,
             0,
             Intent(this, StopReceiver::class.java),
-            PendingIntent.FLAG_IMMUTABLE
+            pendingIntentFlags
         )
         val stopAction =
             NotificationCompat.Action(0, getString(R.string.action_kill), stopPendingIntent)

--- a/app/src/main/java/taco/scoop/core/service/indicator/IndicatorService.kt
+++ b/app/src/main/java/taco/scoop/core/service/indicator/IndicatorService.kt
@@ -24,7 +24,7 @@ open class IndicatorService : Service() {
             this,
             0,
             Intent(this, StopReceiver::class.java),
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_IMMUTABLE
         )
         val stopAction =
             NotificationCompat.Action(0, getString(R.string.action_kill), stopPendingIntent)

--- a/app/src/main/java/taco/scoop/util/Utils.kt
+++ b/app/src/main/java/taco/scoop/util/Utils.kt
@@ -2,6 +2,7 @@
 
 package taco.scoop.util
 
+import android.app.PendingIntent
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -20,6 +21,13 @@ import androidx.core.graphics.drawable.updateBounds
 import taco.scoop.core.data.crash.CrashLoader
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
+
+val pendingIntentFlags
+    get() =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+            PendingIntent.FLAG_IMMUTABLE
+        else
+            PendingIntent.FLAG_UPDATE_CURRENT
 
 fun Context.getAttrColor(attr: Int): Int {
     val ta = this.obtainStyledAttributes(intArrayOf(attr))


### PR DESCRIPTION
- Fixes compilation error that happens because of `compileSdk` being set to 30 while android libraries already set it to 31
- Fully supports Android 12 and its policies