### PR TITLE
Switch to Intent getter instead of storing it in memory

### DIFF
--- a/app/src/main/java/taco/scoop/util/ServiceUtils.kt
+++ b/app/src/main/java/taco/scoop/util/ServiceUtils.kt
@@ -7,11 +7,9 @@ import android.os.HandlerThread
 import androidx.core.content.ContextCompat
 import taco.scoop.core.service.detector.CrashDetectorService
 
-lateinit var intent: Intent
 var isServiceActive = false
 
 fun Context.initScoopService() {
-    checkIntentInit()
     if (!isServiceActive) {
         val thread = HandlerThread("startCrashDetector")
         thread.start()
@@ -24,17 +22,14 @@ fun Context.startScoopService(): Boolean {
     if (!isPermissionGranted())
         return false
 
-    ContextCompat.startForegroundService(this, intent)
+    ContextCompat.startForegroundService(this, serviceIntent)
     return true
 }
 
 fun Context.stopScoopService() {
-    checkIntentInit()
-    if (stopService(intent))
+    if (stopService(serviceIntent))
         isServiceActive = false
 }
 
-private fun Context.checkIntentInit() {
-    if (!::intent.isInitialized)
-        intent = Intent(this, CrashDetectorService::class.java)
-}
+private val Context.serviceIntent
+    get() = Intent(this, CrashDetectorService::class.java)


### PR DESCRIPTION
Looking over at Android docs and other resources (*cough* StackOverflow *cough*), they all spawn new Intent objects instead of storing them in memory. I guess it's easier to spawn new Intent instead of storing it in memory and then checking if it's initialized.

(also makes code a bit more readable IMO)