### PR TITLE
Android 12 support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 31
+    buildToolsVersion "31.0.0"
 
     defaultConfig {
         applicationId "taco.scoop"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 31
         versionName "2.3.1"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,11 +88,10 @@
             </intent-filter>
         </receiver>
         <receiver
-            android:name=".core.receiver.ShareReceiver"
+            android:name=".core.receiver.NotificationActionReceiver"
             android:exported="true"
             tools:ignore="ExportedReceiver">
             <intent-filter>
-                <action android:name="taco.scoop.ACTION_SHARE" />
                 <action android:name="taco.scoop.ACTION_COPY" />
             </intent-filter>
         </receiver>

--- a/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
+++ b/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
@@ -1,5 +1,7 @@
 package taco.scoop.core.receiver;
 
+import static taco.scoop.util.Utils.setPendingIntentFlag;
+
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -71,7 +73,7 @@ public class CrashReceiver extends BroadcastReceiver {
             TaskStackBuilder stackBuilder = TaskStackBuilder.create(context)
                     .addParentStack(DetailActivity.class)
                     .addNextIntent(clickIntent);
-            PendingIntent clickPendingIntent = stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent clickPendingIntent = stackBuilder.getPendingIntent(0, setPendingIntentFlag());
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context, "crashes")
                     .setSmallIcon(R.drawable.ic_bug_report)
@@ -105,7 +107,7 @@ public class CrashReceiver extends BroadcastReceiver {
                         .putExtra("pkg", packageName)
                         .setAction(Intents.INTENT_ACTION_COPY);
                 PendingIntent copyPendingIntent = PendingIntent.getBroadcast(context,
-                        notificationId, copyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        notificationId, copyIntent, setPendingIntentFlag());
                 builder.addAction(new NotificationCompat.Action(R.drawable.ic_content_copy,
                         context.getString(R.string.action_copy_short), copyPendingIntent));
 
@@ -114,7 +116,7 @@ public class CrashReceiver extends BroadcastReceiver {
                         .putExtra("pkg", packageName)
                         .setAction(Intents.INTENT_ACTION_SHARE);
                 PendingIntent sharePendingIntent = PendingIntent.getBroadcast(context,
-                        notificationId, shareIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        notificationId, shareIntent, setPendingIntentFlag());
                 builder.addAction(new NotificationCompat.Action(R.drawable.ic_share,
                         context.getString(R.string.action_share), sharePendingIntent));
             }

--- a/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
+++ b/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
@@ -103,7 +103,7 @@ public class CrashReceiver extends BroadcastReceiver {
             int notificationId = (int) (time - ScoopApplication.getBootTime());
 
             if (PreferenceHelper.showActionButtons()) {
-                Intent copyIntent = new Intent(context, ShareReceiver.class)
+                Intent copyIntent = new Intent(context, NotificationActionReceiver.class)
                         .putExtra("stackTrace", stackTrace)
                         .putExtra("pkg", packageName)
                         .setAction(Intents.INTENT_ACTION_COPY);
@@ -112,12 +112,15 @@ public class CrashReceiver extends BroadcastReceiver {
                 builder.addAction(new NotificationCompat.Action(R.drawable.ic_content_copy,
                         context.getString(R.string.action_copy_short), copyPendingIntent));
 
-                Intent shareIntent = new Intent(context, ShareReceiver.class)
+                Intent shareIntent = new Intent(Intent.ACTION_SEND)
                         .putExtra("stackTrace", stackTrace)
                         .putExtra("pkg", packageName)
-                        .setAction(Intents.INTENT_ACTION_SHARE);
-                PendingIntent sharePendingIntent = PendingIntent.getBroadcast(context,
-                        notificationId, shareIntent, setPendingIntentFlag());
+                        .setType("text/plain")
+                        .putExtra(Intent.EXTRA_TEXT, stackTrace);
+                final Intent shareChooserIntent = Intent.createChooser(shareIntent, null)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                PendingIntent sharePendingIntent = PendingIntent.getActivity(context,
+                        notificationId, shareChooserIntent, setPendingIntentFlag());
                 builder.addAction(new NotificationCompat.Action(R.drawable.ic_share,
                         context.getString(R.string.action_share), sharePendingIntent));
             }

--- a/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
+++ b/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.java
@@ -85,6 +85,7 @@ public class CrashReceiver extends BroadcastReceiver {
                     .setColor(ContextCompat.getColor(context, R.color.colorAccent))
                     .setAutoCancel(true)
                     .setOnlyAlertOnce(true)
+                    .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
                     .setGroup("crashes")
                     .setContentIntent(clickPendingIntent);
 

--- a/app/src/main/java/taco/scoop/core/receiver/NotificationActionReceiver.kt
+++ b/app/src/main/java/taco/scoop/core/receiver/NotificationActionReceiver.kt
@@ -8,20 +8,11 @@ import taco.scoop.util.Intents
 import taco.scoop.util.copyTextToClipboard
 import taco.scoop.util.displayToast
 
-class ShareReceiver : BroadcastReceiver() {
+class NotificationActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         val stackTrace = intent?.getStringExtra("stackTrace")
         val pkg = intent?.getStringExtra("pkg")
         when (intent?.action) {
-            Intents.INTENT_ACTION_SHARE -> {
-                val shareIntent = Intent(Intent.ACTION_SEND)
-                    .setType("text/plain")
-                    .putExtra(Intent.EXTRA_TEXT, stackTrace)
-                context.startActivity(
-                    Intent.createChooser(shareIntent, context.getString(R.string.action_share))
-                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                )
-            }
             Intents.INTENT_ACTION_COPY -> {
                 context.copyTextToClipboard(R.string.copy_label, pkg, stackTrace)
                 context.displayToast(R.string.copied_toast)

--- a/app/src/main/java/taco/scoop/core/service/indicator/IndicatorService.kt
+++ b/app/src/main/java/taco/scoop/core/service/indicator/IndicatorService.kt
@@ -8,6 +8,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import taco.scoop.R
 import taco.scoop.core.receiver.StopReceiver
+import taco.scoop.util.setPendingIntentFlag
 
 open class IndicatorService : Service() {
 
@@ -24,7 +25,7 @@ open class IndicatorService : Service() {
             this,
             0,
             Intent(this, StopReceiver::class.java),
-            PendingIntent.FLAG_UPDATE_CURRENT
+            setPendingIntentFlag()
         )
         val stopAction =
             NotificationCompat.Action(0, getString(R.string.action_kill), stopPendingIntent)

--- a/app/src/main/java/taco/scoop/util/Intents.kt
+++ b/app/src/main/java/taco/scoop/util/Intents.kt
@@ -3,7 +3,6 @@ package taco.scoop.util
 object Intents {
     const val INTENT_ACTION = "taco.scoop.EXCEPTION"
     const val INTENT_ACTION_COPY = "taco.scoop.ACTION_COPY"
-    const val INTENT_ACTION_SHARE = "taco.scoop.ACTION_SHARE"
 
     const val INTENT_PACKAGE_NAME = "pkg"
     const val INTENT_TIME = "time"

--- a/app/src/main/java/taco/scoop/util/Utils.kt
+++ b/app/src/main/java/taco/scoop/util/Utils.kt
@@ -2,6 +2,7 @@
 
 package taco.scoop.util
 
+import android.app.PendingIntent
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -98,5 +99,13 @@ fun Context.openSystemNotificationSettings() {
         }.also(this::startActivity)
     } catch (e: Exception) {
         e.printStackTrace()
+    }
+}
+
+fun setPendingIntentFlag(): Int {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
     }
 }


### PR DESCRIPTION
Tested and working!

Context behind changes:

2nd commit:
- https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

3rd commit:
- https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder#setForegroundServiceBehavior(int)

4th commit:
- https://developer.android.com/about/versions/12/behavior-changes-12#notification-trampolines

---------------------------------------------

Also improves notification drawer behavior when tapping "Share" on a crash notification with the drawer open:
- Before: Chooser would appear behind the notification drawer in the system UI. The drawer would have to be manually closed / dismissed before interaction with the chooser UI was possible.
- After: Notification drawer is dismissed automatically, and the chooser UI appears afterward. This is much less confusing for end users.
