### PR TITLE
Add Paste Uploader

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="taco.scoop"
     android:installLocation="internalOnly">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.kt
+++ b/app/src/main/java/taco/scoop/core/receiver/CrashReceiver.kt
@@ -151,7 +151,7 @@ class CrashReceiver : BroadcastReceiver() {
         )
         addAction(
             NotificationCompat.Action(
-                R.drawable.ic_share,
+                android.R.drawable.ic_menu_share,
                 context.getString(R.string.action_share), sharePendingIntent
             )
         )

--- a/app/src/main/java/taco/scoop/ui/activity/DetailActivity.kt
+++ b/app/src/main/java/taco/scoop/ui/activity/DetailActivity.kt
@@ -3,22 +3,26 @@ package taco.scoop.ui.activity
 import android.os.Bundle
 import android.text.Spannable
 import android.text.style.BackgroundColorSpan
+import android.util.Log
 import android.util.TypedValue
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.core.app.ShareCompat
 import androidx.core.text.toSpannable
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import com.topjohnwu.superuser.internal.Utils
 import taco.scoop.R
 import taco.scoop.core.data.crash.Crash
 import taco.scoop.core.data.crash.CrashLoader
 import taco.scoop.databinding.ActivityDetailBinding
 import taco.scoop.util.*
 import java.util.*
+import kotlin.concurrent.thread
 
 class DetailActivity : AppCompatActivity(), SearchView.OnQueryTextListener,
     SearchView.OnCloseListener {
@@ -128,6 +132,26 @@ class DetailActivity : AppCompatActivity(), SearchView.OnQueryTextListener,
                     .setChooserTitle(R.string.action_share)
                     .createChooserIntent()
                 startActivity(intent)
+                return true
+            }
+            R.id.menu_detail_create_paste -> {
+                thread {
+                    val message = try {
+                        val url = createPaste(mCrash!!.stackTrace)
+                        copyToClipboard("PasteURL", url)
+                        "YOP"
+                    } catch (ex: Exception) {
+                        Log.e("scoop", "UHOH", ex)
+                        when (ex) {
+                            is PasteException -> ex.message!!
+                            else -> "Failed to upload paste: ${ex.message}"
+                        }
+                    }
+                    runOnUiThread {
+                        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+                    }
+                }
+
                 return true
             }
         }

--- a/app/src/main/java/taco/scoop/ui/activity/DetailActivity.kt
+++ b/app/src/main/java/taco/scoop/ui/activity/DetailActivity.kt
@@ -136,14 +136,14 @@ class DetailActivity : AppCompatActivity(), SearchView.OnQueryTextListener,
             R.id.menu_detail_create_paste -> {
                 thread {
                     val message = try {
-                        val url = createPaste(mCrash!!.stackTrace)
+                        val url = createPaste(this, mCrash!!.stackTrace)
                         copyToClipboard("PasteURL", url)
-                        "YOP"
+                        getString(R.string.create_paste_success)
                     } catch (ex: Exception) {
-                        Log.e("scoop", "UHOH", ex)
+                        Log.e("scoop", "Failed to create Paste", ex)
                         when (ex) {
                             is PasteException -> ex.message!!
-                            else -> "Failed to upload paste: ${ex.message}"
+                            else -> getString(R.string.create_paste_fail, ex.message ?: "-")
                         }
                     }
                     runOnUiThread {

--- a/app/src/main/java/taco/scoop/ui/activity/DetailActivity.kt
+++ b/app/src/main/java/taco/scoop/ui/activity/DetailActivity.kt
@@ -15,7 +15,6 @@ import androidx.core.app.ShareCompat
 import androidx.core.text.toSpannable
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import com.topjohnwu.superuser.internal.Utils
 import taco.scoop.R
 import taco.scoop.core.data.crash.Crash
 import taco.scoop.core.data.crash.CrashLoader

--- a/app/src/main/java/taco/scoop/util/PasteUtils.kt
+++ b/app/src/main/java/taco/scoop/util/PasteUtils.kt
@@ -1,0 +1,31 @@
+package taco.scoop.util
+
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+class PasteException(message: String) : Exception(message) {}
+
+fun createPaste(text: String): String {
+    val url = PreferenceHelper.pasteUrl
+        ?: throw PasteException("Setup a Paste Service in Settings and try again")
+
+    val template = PreferenceHelper.pasteTemplate ?: "$url/%s"
+
+    val conn = URL(url).openConnection() as HttpURLConnection
+    conn.requestMethod = "POST"
+    conn.addRequestProperty("User-Agent", "Scoop (https://github.com/TacoTheDank/Scoop)")
+    conn.addRequestProperty("Content-Type", "text/plain")
+    conn.addRequestProperty("Accept", "application/json")
+    conn.doOutput = true
+    conn.outputStream.use {
+        it.write(text.toByteArray())
+    }
+
+    val res = conn.inputStream.use {
+        it.bufferedReader().readText()
+    }
+
+    val key = JSONObject(res).getString(PreferenceHelper.pasteResponseJsonKey ?: "key")
+    return template.format(key)
+}

--- a/app/src/main/java/taco/scoop/util/PasteUtils.kt
+++ b/app/src/main/java/taco/scoop/util/PasteUtils.kt
@@ -1,14 +1,16 @@
 package taco.scoop.util
 
+import android.content.Context
 import org.json.JSONObject
+import taco.scoop.R
 import java.net.HttpURLConnection
 import java.net.URL
 
 class PasteException(message: String) : Exception(message) {}
 
-fun createPaste(text: String): String {
+fun createPaste(context: Context, text: String): String {
     val url = PreferenceHelper.pasteUrl
-        ?: throw PasteException("Setup a Paste Service in Settings and try again")
+        ?: throw PasteException(context.getString(R.string.setup_paste_service))
 
     val template = PreferenceHelper.pasteTemplate ?: "$url/%s"
 

--- a/app/src/main/java/taco/scoop/util/PreferenceHelper.kt
+++ b/app/src/main/java/taco/scoop/util/PreferenceHelper.kt
@@ -6,7 +6,6 @@ import android.content.res.Resources
 import androidx.annotation.StringRes
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
-import org.jetbrains.annotations.Contract
 import taco.scoop.R
 
 object PreferenceHelper {

--- a/app/src/main/java/taco/scoop/util/PreferenceHelper.kt
+++ b/app/src/main/java/taco/scoop/util/PreferenceHelper.kt
@@ -6,6 +6,7 @@ import android.content.res.Resources
 import androidx.annotation.StringRes
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
+import org.jetbrains.annotations.Contract
 import taco.scoop.R
 
 object PreferenceHelper {
@@ -23,6 +24,10 @@ object PreferenceHelper {
 
     private fun getSharedBoolean(@StringRes key: Int, defValue: Boolean): Boolean {
         return sharedPreferences.getBoolean(getKey(key), defValue)
+    }
+
+    private fun getSharedString(@StringRes key: Int, defValue: String?): String? {
+        return sharedPreferences.getString(getKey(key), defValue)
     }
 
     val showNotifications: Boolean
@@ -55,10 +60,17 @@ object PreferenceHelper {
     val forceEnglish: Boolean
         get() = getSharedBoolean(R.string.prefKey_force_english, false)
 
+    val pasteUrl: String?
+        get() = getSharedString(R.string.prefKey_paste_url, null)
+
+    val pasteTemplate: String?
+        get() = getSharedString(R.string.prefKey_paste_template, null)
+
+    val pasteResponseJsonKey: String?
+        get() = getSharedString(R.string.prefKey_paste_response_json_key, "key")
+
     private val blacklistedPackages: String?
-        get() = sharedPreferences.getString(
-            getKey(R.string.key_blacklisted_packages), ""
-        )
+        get() = getSharedString(R.string.key_blacklisted_packages, null)
 
     val blacklistList: List<String>
         get() = listOf(*blacklistedPackages?.split(",".toRegex())!!.toTypedArray())

--- a/app/src/main/java/taco/scoop/util/Utils.kt
+++ b/app/src/main/java/taco/scoop/util/Utils.kt
@@ -37,7 +37,7 @@ fun Context.getAttrColor(attr: Int): Int {
  * @param label  User-visible label for the clip data.
  * @param text   The actual text in the clip.
  */
-private fun Context.copyToClipboard(label: CharSequence?, text: CharSequence?) {
+fun Context.copyToClipboard(label: CharSequence?, text: CharSequence?) {
     val clipboard = this.getSystemService<ClipboardManager>()
     val data = ClipData.newPlainText(label, text)
     clipboard?.setPrimaryClip(data)

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z" />
-</vector>

--- a/app/src/main/res/menu/menu_detail.xml
+++ b/app/src/main/res/menu/menu_detail.xml
@@ -5,7 +5,7 @@
     <item
         android:id="@+id/menu_detail_search"
         android:icon="@drawable/ic_search"
-        android:title="@string/action_search"
+        android:title="@android:string/search_go"
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         app:iconTint="?android:textColorSecondary"
         app:showAsAction="always|collapseActionView" />
@@ -20,14 +20,21 @@
     <item
         android:id="@+id/menu_detail_copy"
         android:icon="@drawable/ic_content_copy"
-        android:title="@string/action_copy"
+        android:title="@android:string/copy"
         app:iconTint="?android:textColorSecondary"
         app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/menu_detail_share"
-        android:icon="@drawable/ic_share"
+        android:icon="@android:drawable/ic_menu_share"
         android:title="@string/action_share"
+        app:iconTint="?android:textColorSecondary"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/menu_detail_create_paste"
+        android:icon="@android:drawable/ic_menu_upload"
+        android:title="@string/action_create_paste"
         app:iconTint="?android:textColorSecondary"
         app:showAsAction="ifRoom" />
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -13,6 +13,12 @@
     <string name="action_copy">In Zwischenablage kopieren</string>
     <string name="action_copy_short">Kopieren</string>
     <string name="action_delete">Löschen</string>
+    <string name="action_create_paste">Paste erstellen</string>
+
+    <!-- Paste -->
+    <string name="setup_paste_service">Kein Paste-Dienst konfiguriert. Richte einen in den Einstellungen ein und versuche es erneut.</string>
+    <string name="create_paste_success">Paste erfolgreich erstellt. URL in die Zwischenablage kopiert.</string>
+    <string name="create_paste_fail">"Beim Erstellen des Pastes ist ein Fehler aufgetreten: %1$s"</string>
 
     <!-- Main activity stuff -->
     <string name="just_now">Gerade eben</string>
@@ -56,7 +62,7 @@
     <string name="settings_combine_same_apps">Selbe Apps kombinieren</string>
     <string name="settings_combine_same_apps_summary">Sortiere Crashes nach individuellen Appeinträgen, welche die verschiedenen Crashes enthalten</string>
     <string name="settings_combine_same_trace">Selbe Crashes kombinieren</string>
-    <string name="settings_combine_same_trace_summary">Kombiniere Crashes von der selben App mit gleichen Stacktraces in einen Eintrag</string>
+    <string name="settings_combine_same_trace_summary">Kombiniere Crashes von derselben App mit gleichen Stacktraces in einen Eintrag</string>
     <string name="settings_search_pkg">Suche im Paketnamen</string>
     <string name="settings_search_pkg_summary">Suche den gegebenen Term im Appnamen sowie im Paketnamen</string>
     <string name="settings_blacklisted_apps">Ausnahmen</string>
@@ -65,6 +71,14 @@
     <!-- Settings (detail view) -->
     <string name="settings_auto_wrap">Automatischer Zeilenumbruch</string>
     <string name="settings_auto_wrap_summary">Begrenzt die maximale Zeilenbreite auf die Bildschirmbreite</string>
+
+    <!-- Settings (paste service) -->
+    <string name="paste_service">Paste-Dienst</string>
+    <string name="paste_url_summary">Die URL, z.B. https://hastebin.cc/documents</string>
+    <string name="paste_json_key_summary">Der Schlüssel der Paste-ID in der JSON-Antwort. Gibt der Dienst {\"key\":\"PasteID\"}, zurück, so sollte dies key sein.</string>
+    <string name="paste_template_summary">URL, wo der Paste gefunden werden kann. Sollte Platzhalter %s enthalten. Dieser wird mit der Paste-ID ersetzt. Z.B. https://hastebin.cc/%s</string>
+    <string name="paste_template_title">Paste URL mit Platzhalter</string>
+    <string name="paste_json_key_title">Paste-ID Schlüsel</string>
 
     <!-- Settings (miscellaneous) -->
     <string name="settings_permission_status">Berechtigungsstatus</string>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -22,4 +22,8 @@
     <string name="prefKey_ignore_threaddeath">ignore_threaddeath</string>
     <string name="prefKey_force_english">force_english</string>
     <string name="prefKey_about_scoop">pref_about_scoop</string>
+
+    <string name="prefKey_paste_url">pref_uploader_url</string>
+    <string name="prefKey_paste_response_json_key">pref_uploader_json_key</string>
+    <string name="prefKey_paste_template">pref_uploader_template</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_copy">Copy to clipboard</string>
     <string name="action_copy_short">Copy</string>
     <string name="action_delete">Delete</string>
+    <string name="action_create_paste">Create Paste</string>
 
     <!-- Main activity stuff -->
     <string name="just_now">Just Now</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,11 @@
     <string name="action_delete">Delete</string>
     <string name="action_create_paste">Create Paste</string>
 
+    <!-- Paste -->
+    <string name="setup_paste_service">No paste service configured. Set one up in the settings and try again.</string>
+    <string name="create_paste_success">Successfully created paste. URL copied to clipboard.</string>
+    <string name="create_paste_fail">"Failed to create paste: %1$s"</string>
+
     <!-- Main activity stuff -->
     <string name="just_now">Just Now</string>
     <string name="crash_count">%1$s (%2$d)</string>
@@ -66,6 +71,14 @@
     <!-- Settings (detail view) -->
     <string name="settings_auto_wrap">Automatic line wrap</string>
     <string name="settings_auto_wrap_summary">Limit maximum line width to screen width</string>
+
+    <!-- Settings (paste service) -->
+    <string name="paste_service">Paste Service</string>
+    <string name="paste_url_summary">The paste service URL, e.g. https://hastebin.cc/documents</string>
+    <string name="paste_json_key_summary">The key of the paste id in the JSON response. If the service returns {\"key\":\"PasteID\"}, this should be key.</string>
+    <string name="paste_template_summary">URL where the created paste can be found. Should contain %s which will be replaced with the paste ID. E.g. https://hastebin.cc/%s</string>
+    <string name="paste_template_title">Paste URL Template</string>
+    <string name="paste_json_key_title">Paste ID key</string>
 
     <!-- Settings (miscellaneous) -->
     <string name="settings_permission_status">Permission status</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -84,6 +84,24 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="Paste Uploader"
+        app:iconSpaceReserved="false">
+        <EditTextPreference
+            android:key="@string/prefKey_paste_url"
+            android:title="URL"
+            app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:defaultValue="key"
+            android:key="@string/prefKey_paste_response_json_key"
+            android:title="PasteID key in json response"
+            app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:key="@string/prefKey_paste_template"
+            android:title="Paste URL template"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:title="@string/settings_misc"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -85,20 +85,24 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="Paste Uploader"
+        android:title="@string/paste_service"
         app:iconSpaceReserved="false">
+
         <EditTextPreference
             android:key="@string/prefKey_paste_url"
             android:title="URL"
+            android:summary="@string/paste_url_summary"
             app:iconSpaceReserved="false" />
         <EditTextPreference
             android:defaultValue="key"
             android:key="@string/prefKey_paste_response_json_key"
-            android:title="PasteID key in json response"
+            android:title="@string/paste_json_key_title"
+            android:summary="@string/paste_json_key_summary"
             app:iconSpaceReserved="false" />
         <EditTextPreference
             android:key="@string/prefKey_paste_template"
-            android:title="Paste URL template"
+            android:title="@string/paste_template_title"
+            android:summary="@string/paste_template_summary"
             app:iconSpaceReserved="false" />
 
     </PreferenceCategory>


### PR DESCRIPTION
The way it works is that you set up a paste service in settings, where you specify
- paste URL (eg https://mypasteservice.com/new)
- the name of the paste id property in the response json (eg key)
- A template for the paste url that takes one %s for the paste id retrieved in step 2 (eg https://mypasteservice.com/paste/%s")
The goal is to be as versatile as possible and support most pastes out of the box

Tried with my own hastebin (URL = https://hb.vendicated.dev/documents, template = https://hb.vendicated.dev/%s")

I'm not sure how exactly translations work, so maybe the new strings need to be added to the translations

Finally I also changed some strings / drawables to use android's resources to have less strings to translate/drawables